### PR TITLE
Implement orchestrator governance controls

### DIFF
--- a/GOVERNANCE_LOG.md
+++ b/GOVERNANCE_LOG.md
@@ -1,0 +1,4 @@
+# Governance Log
+
+| Timestamp | Job ID | Attestation Digest |
+| --- | --- | --- |

--- a/src/multiai/orchestrator/attest.py
+++ b/src/multiai/orchestrator/attest.py
@@ -1,12 +1,95 @@
-import json, time, hashlib, pathlib
-def write_attestation(paths, out_path="ai_attestation.json", tool="guarded-merge"):
-    rec = {"tool": tool, "time": int(time.time()), "artifacts": []}
-    for p in paths:
-        pp = pathlib.Path(p)
-        if pp.exists() and pp.is_file():
-            h = hashlib.sha256(pp.read_bytes()).hexdigest()
-            rec["artifacts"].append({"path": str(pp), "sha256": h})
-    pathlib.Path(out_path).write_text(json.dumps(rec, indent=2), encoding="utf-8")
-    return out_path
-if __name__ == "__main__":
-    write_attestation(["core_protocol.md","policies/rules.yml"])
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+DEFAULT_TOOL = "guarded-merge"
+DEFAULT_ATTESTATION_PATH = "ai_attestation.json"
+GOVERNANCE_LOG_PATH = Path("GOVERNANCE_LOG.md")
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _hash_file(path: Path) -> str | None:
+    if not path.exists() or not path.is_file():
+        return None
+    return _sha256_bytes(path.read_bytes())
+
+
+def _materialise_entries(paths: Iterable[str]) -> list[dict[str, str | bool]]:
+    entries: list[dict[str, str | bool]] = []
+    for raw in paths:
+        if not raw:
+            continue
+        p = Path(raw)
+        info: dict[str, str | bool] = {"path": str(p), "exists": p.exists()}
+        file_hash = _hash_file(p)
+        if file_hash:
+            info["sha256"] = file_hash
+        entries.append(info)
+    return entries
+
+
+def _ensure_parent(path: Path) -> None:
+    if path.parent:
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _append_governance_log(timestamp: str, job_id: str, digest: str) -> None:
+    header = "# Governance Log\n\n| Timestamp | Job ID | Attestation Digest |\n| --- | --- | --- |\n"
+    if not GOVERNANCE_LOG_PATH.exists():
+        GOVERNANCE_LOG_PATH.write_text(header, encoding="utf-8")
+    with GOVERNANCE_LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(f"| {timestamp} | {job_id} | {digest} |\n")
+
+
+def write_attestation(
+    job_id: str,
+    *,
+    validators: Sequence[Mapping[str, str]],
+    rule_paths: Sequence[str],
+    diff_paths: Sequence[str],
+    execution_logs: Sequence[Mapping[str, object]],
+    prompt: str,
+    out_path: str = DEFAULT_ATTESTATION_PATH,
+    tool: str = DEFAULT_TOOL,
+    signature_secret: str | None = None,
+) -> str:
+    """Emit an attestation payload and append the digest to the governance log."""
+
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    prompt_digest = _sha256_bytes(prompt.encode("utf-8"))
+
+    payload = {
+        "job_id": job_id,
+        "tool": tool,
+        "timestamp": timestamp,
+        "validators": list(validators),
+        "rules": _materialise_entries(rule_paths),
+        "diffs": _materialise_entries(diff_paths),
+        "execution_logs": list(execution_logs),
+        "prompt_sha256": prompt_digest,
+    }
+
+    digest = _sha256_bytes(json.dumps(payload, sort_keys=True).encode("utf-8"))
+    secret = signature_secret or os.environ.get("MULTIAI_ATTESTATION_SECRET", "")
+    signature = _sha256_bytes((digest + secret).encode("utf-8"))
+
+    payload["digest"] = digest
+    payload["signature"] = signature
+
+    out = Path(out_path)
+    _ensure_parent(out)
+    out.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    _append_governance_log(timestamp, job_id, digest)
+    return str(out)
+
+
+__all__ = ["write_attestation", "DEFAULT_ATTESTATION_PATH", "GOVERNANCE_LOG_PATH"]

--- a/src/multiai/orchestrator/gateway.py
+++ b/src/multiai/orchestrator/gateway.py
@@ -1,15 +1,208 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+from . import attest, github_app, locks, prompt_guard
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TOOLS_DIR = REPO_ROOT / "tools"
+DEFAULT_POLICY_PATH = str(Path("policies") / "gates.yml")
+DEFAULT_RULES_PATH = str(Path("policies") / "rules.yml")
+
+VALIDATOR_VERSIONS: Dict[str, str] = {
+    "llama_guard": "1.0",
+    "protocol_auditor": "1.0",
+    "gpt_math_validate": "1.0",
+}
+
 
 @dataclass
 class ChangeProposal:
-    shards: list[str]
+    job_id: str
+    shards: Sequence[str]
     title: str
-    description: str
+    prompt: str
+    description: str = ""
+    diff_paths: Sequence[str] = field(default_factory=list)
+    branch: Optional[str] = None
+    requires_math: bool = False
+
 
 class Orchestrator:
+    def __init__(
+        self,
+        *,
+        lease_manager: Optional[locks.LeaseManager] = None,
+        policy_path: str = DEFAULT_POLICY_PATH,
+        rules_path: str = DEFAULT_RULES_PATH,
+    ) -> None:
+        self._lease_manager = lease_manager or locks.LeaseManager()
+        self._policy_path = policy_path
+        self._rules_path = rules_path
+        self._current_cp: Optional[ChangeProposal] = None
+        self._sanitized_prompt: str = ""
+        self._leases: Dict[str, locks.Lease] = {}
+        self._execution_logs: List[Dict[str, object]] = []
+        self._validator_status: Dict[str, str] = {}
+
+    # -- lifecycle ------------------------------------------------------
+
+    def _reset(self) -> None:
+        self._current_cp = None
+        self._sanitized_prompt = ""
+        self._leases = {}
+        self._execution_logs = []
+        self._validator_status = {}
+
     def prepare(self, cp: ChangeProposal) -> None:
-        print("prepare:", cp.title)
+        if self._current_cp is not None:
+            raise RuntimeError("another change proposal is already active")
+        sanitized = prompt_guard.sanitize(cp.prompt or cp.description)
+        self._current_cp = cp
+        self._sanitized_prompt = sanitized
+        if cp.shards:
+            self._leases = self._lease_manager.acquire(cp.shards, holder=cp.job_id)
+        self._log_event(
+            "lease_acquired",
+            {
+                "shards": list(cp.shards),
+                "holder": cp.job_id,
+            },
+        )
+
     def validate_local(self) -> None:
-        print("validate local: Llama-Guard, Protocol-Auditor, GPT-Math-Validate")
-    def open_pr(self) -> None:
-        print("open PR (GitHub App to be wired)")
+        cp = self._require_cp()
+        prompt_bytes = self._sanitized_prompt.encode("utf-8")
+        self._execution_logs = []
+        self._validator_status = {}
+
+        self._run_validator(
+            "llama_guard",
+            [sys.executable, str(TOOLS_DIR / "llama_guard.py"), "--policy", self._rules_path],
+            prompt_bytes,
+        )
+        self._run_validator(
+            "protocol_auditor",
+            [
+                sys.executable,
+                str(TOOLS_DIR / "protocol_auditor.py"),
+                "--policy",
+                self._policy_path,
+                "--rules",
+                self._rules_path,
+            ],
+            prompt_bytes,
+        )
+        if self._should_run_math(cp):
+            paths = [str(Path(p)) for p in (cp.diff_paths or [])]
+            self._run_validator(
+                "gpt_math_validate",
+                [sys.executable, str(TOOLS_DIR / "gpt_math_validate.py"), *paths],
+                None,
+            )
+        # renew leases after validation pass to keep TTL fresh
+        if self._leases:
+            self._lease_manager.renew(cp.shards, holder=cp.job_id)
+
+    def open_pr(self) -> str:
+        cp = self._require_cp()
+        attestation_path = attest.write_attestation(
+            cp.job_id,
+            validators=self._build_validator_report(),
+            rule_paths=[self._policy_path, self._rules_path],
+            diff_paths=[str(Path(p)) for p in (cp.diff_paths or [])],
+            execution_logs=self._execution_logs,
+            prompt=self._sanitized_prompt,
+        )
+        branch_name = cp.branch or f"ai/{cp.job_id}"
+        github_app.push_branch(branch_name, attestation_path=attestation_path, title=cp.title)
+        self._release_leases()
+        self._reset()
+        return attestation_path
+
+    def abort(self) -> None:
+        self._release_leases()
+        self._reset()
+
+    # -- helpers --------------------------------------------------------
+
+    def _require_cp(self) -> ChangeProposal:
+        if self._current_cp is None:
+            raise RuntimeError("no active change proposal")
+        return self._current_cp
+
+    def _log_event(self, name: str, data: Optional[Dict[str, object]] = None) -> None:
+        self._execution_logs.append(
+            {
+                "timestamp": time.time(),
+                "event": name,
+                "payload": data or {},
+            }
+        )
+
+    def _run_validator(self, name: str, cmd: List[str], input_bytes: Optional[bytes]) -> None:
+        started = time.time()
+        proc = subprocess.run(
+            cmd,
+            input=input_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        finished = time.time()
+        log_entry = {
+            "timestamp": finished,
+            "validator": name,
+            "command": cmd,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.decode("utf-8", errors="ignore").strip(),
+            "stderr": proc.stderr.decode("utf-8", errors="ignore").strip(),
+            "duration": finished - started,
+        }
+        self._execution_logs.append(log_entry)
+        if proc.returncode != 0:
+            self._validator_status[name] = "fail"
+            raise RuntimeError(f"validator {name} failed: {log_entry['stderr'] or log_entry['stdout']}")
+        self._validator_status[name] = "pass"
+
+    def _should_run_math(self, cp: ChangeProposal) -> bool:
+        if cp.requires_math:
+            return True
+        for path in cp.diff_paths or []:
+            lower = path.lower()
+            if lower.endswith((".py", ".ipynb")):
+                return True
+            if any(token in lower for token in ("math", "calc", "formula", "model")):
+                return True
+        return False
+
+    def _build_validator_report(self) -> List[Dict[str, str]]:
+        report: List[Dict[str, str]] = []
+        for name, version in VALIDATOR_VERSIONS.items():
+            status = self._validator_status.get(name, "skipped")
+            report.append({
+                "name": name,
+                "version": version,
+                "status": status,
+            })
+        return report
+
+    def _release_leases(self) -> None:
+        if not self._current_cp or not self._leases:
+            return
+        try:
+            self._lease_manager.release(self._current_cp.shards, holder=self._current_cp.job_id)
+            self._log_event(
+                "lease_released",
+                {"shards": list(self._current_cp.shards), "holder": self._current_cp.job_id},
+            )
+        finally:
+            self._leases = {}
+
+
+__all__ = ["ChangeProposal", "Orchestrator"]

--- a/src/multiai/orchestrator/github_app.py
+++ b/src/multiai/orchestrator/github_app.py
@@ -1,1 +1,18 @@
-def push_branch(): print('Pushing PR branch...')
+from __future__ import annotations
+
+import json
+import sys
+from typing import Optional
+
+
+def push_branch(branch: str, *, attestation_path: Optional[str] = None, title: Optional[str] = None) -> None:
+    """Stub GitHub App client that records push metadata."""
+    if not branch:
+        raise ValueError("branch name is required for push")
+
+    payload = {
+        "branch": branch,
+        "title": title or "",
+        "attestation": attestation_path or "",
+    }
+    sys.stdout.write("github_app.push_branch " + json.dumps(payload) + "\n")

--- a/src/multiai/orchestrator/locks.py
+++ b/src/multiai/orchestrator/locks.py
@@ -1,1 +1,302 @@
-def lock(path): return True
+from __future__ import annotations
+
+import contextlib
+import os
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterator, List, Optional, Sequence
+
+STATE_DIR = os.environ.get("MULTIAI_STATE_DIR") or "state"
+DEFAULT_DB_PATH = os.path.join(STATE_DIR, "locks.sqlite")
+DEFAULT_TTL_SECONDS = 15 * 60  # 15 minutes
+DEFAULT_HEARTBEAT_SECONDS = 60
+DEFAULT_ACQUIRE_TIMEOUT = 120  # seconds
+DEFAULT_RETRY_INTERVAL = 1.0
+
+
+class LeaseError(RuntimeError):
+    """Base class for lease related failures."""
+
+
+class LeaseTimeout(LeaseError):
+    """Raised when leases could not be acquired before timeout."""
+
+
+class LeaseNotHeld(LeaseError):
+    """Raised when attempting to renew or release a lease that is not held."""
+
+
+@dataclass(frozen=True)
+class Lease:
+    shard: str
+    holder: str
+    ttl: float
+    heartbeat: float
+    acquired_at: float
+    updated_at: float
+    expires_at: float
+
+
+class LeaseManager:
+    """SQLite-backed lease manager that enforces shard-level mutex semantics."""
+
+    def __init__(
+        self,
+        db_path: str = DEFAULT_DB_PATH,
+        ttl: float = DEFAULT_TTL_SECONDS,
+        heartbeat: float = DEFAULT_HEARTBEAT_SECONDS,
+        acquire_timeout: float = DEFAULT_ACQUIRE_TIMEOUT,
+        retry_interval: float = DEFAULT_RETRY_INTERVAL,
+    ) -> None:
+        self.db_path = db_path
+        self.default_ttl = float(ttl)
+        self.default_heartbeat = float(heartbeat)
+        self.acquire_timeout = float(acquire_timeout)
+        self.retry_interval = float(max(retry_interval, 0.1))
+        self._lock = threading.RLock()
+        self._ensure_parent()
+        self._initialise()
+
+    # -- private helpers -------------------------------------------------
+
+    def _ensure_parent(self) -> None:
+        parent = os.path.dirname(self.db_path) or "."
+        os.makedirs(parent, exist_ok=True)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            self.db_path,
+            timeout=30,
+            isolation_level=None,
+            detect_types=sqlite3.PARSE_DECLTYPES,
+            check_same_thread=False,
+        )
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _initialise(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS leases (
+                    shard TEXT PRIMARY KEY,
+                    holder TEXT NOT NULL,
+                    ttl REAL NOT NULL,
+                    heartbeat_interval REAL NOT NULL,
+                    acquired_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    expires_at REAL NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_leases_holder ON leases(holder)"
+            )
+
+    @contextlib.contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                yield conn
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+
+    @staticmethod
+    def _now() -> float:
+        return time.time()
+
+    def _purge_expired(self, conn: sqlite3.Connection, now: Optional[float] = None) -> None:
+        ts = now if now is not None else self._now()
+        conn.execute("DELETE FROM leases WHERE expires_at <= ?", (ts,))
+
+    @staticmethod
+    def _row_to_lease(row: sqlite3.Row) -> Lease:
+        return Lease(
+            shard=row["shard"],
+            holder=row["holder"],
+            ttl=float(row["ttl"]),
+            heartbeat=float(row["heartbeat_interval"]),
+            acquired_at=float(row["acquired_at"]),
+            updated_at=float(row["updated_at"]),
+            expires_at=float(row["expires_at"]),
+        )
+
+    def _try_acquire(
+        self,
+        conn: sqlite3.Connection,
+        shard: str,
+        holder: str,
+        ttl: Optional[float],
+        heartbeat: Optional[float],
+        now: float,
+    ) -> Optional[Lease]:
+        ttl_val = float(ttl if ttl is not None else self.default_ttl)
+        heartbeat_val = float(heartbeat if heartbeat is not None else self.default_heartbeat)
+        row = conn.execute("SELECT * FROM leases WHERE shard = ?", (shard,)).fetchone()
+        if row is not None and row["holder"] != holder and row["expires_at"] > now:
+            return None
+        acquired_at = row["acquired_at"] if row is not None and row["holder"] == holder else now
+        expires_at = now + ttl_val
+        conn.execute(
+            """
+            INSERT INTO leases(shard, holder, ttl, heartbeat_interval, acquired_at, updated_at, expires_at)
+            VALUES(?,?,?,?,?,?,?)
+            ON CONFLICT(shard) DO UPDATE SET
+                holder=excluded.holder,
+                ttl=excluded.ttl,
+                heartbeat_interval=excluded.heartbeat_interval,
+                acquired_at=excluded.acquired_at,
+                updated_at=excluded.updated_at,
+                expires_at=excluded.expires_at
+            """,
+            (shard, holder, ttl_val, heartbeat_val, acquired_at, now, expires_at),
+        )
+        updated = conn.execute("SELECT * FROM leases WHERE shard = ?", (shard,)).fetchone()
+        return self._row_to_lease(updated)
+
+    # -- public API ------------------------------------------------------
+
+    def acquire(
+        self,
+        shards: Sequence[str],
+        holder: str,
+        ttl: Optional[float] = None,
+        heartbeat: Optional[float] = None,
+        timeout: Optional[float] = None,
+        retry_interval: Optional[float] = None,
+    ) -> Dict[str, Lease]:
+        """Acquire leases for a collection of shards."""
+        unique_shards = sorted({s.strip() for s in shards if s and s.strip()})
+        leases: Dict[str, Lease] = {}
+        if not unique_shards:
+            return leases
+
+        deadline = self._now() + (timeout if timeout is not None else self.acquire_timeout)
+        retry = retry_interval if retry_interval is not None else self.retry_interval
+
+        last_error: Optional[str] = None
+        while self._now() <= deadline:
+            try:
+                with self._transaction() as conn:
+                    leases.clear()
+                    now = self._now()
+                    self._purge_expired(conn, now)
+                    for shard in unique_shards:
+                        lease = self._try_acquire(conn, shard, holder, ttl, heartbeat, now)
+                        if lease is None:
+                            last_error = (
+                                f"shard '{shard}' currently held by another worker"
+                            )
+                            raise LeaseTimeout(last_error)
+                        leases[shard] = lease
+                return dict(leases)
+            except LeaseTimeout:
+                time.sleep(retry)
+                continue
+        raise LeaseTimeout(last_error or "timed out acquiring shard leases")
+
+    def renew(
+        self,
+        shards: Sequence[str],
+        holder: str,
+        ttl: Optional[float] = None,
+        heartbeat: Optional[float] = None,
+    ) -> Dict[str, Lease]:
+        unique_shards = sorted({s.strip() for s in shards if s and s.strip()})
+        renewed: Dict[str, Lease] = {}
+        if not unique_shards:
+            return renewed
+
+        with self._transaction() as conn:
+            now = self._now()
+            self._purge_expired(conn, now)
+            for shard in unique_shards:
+                row = conn.execute("SELECT * FROM leases WHERE shard = ?", (shard,)).fetchone()
+                if row is None or row["holder"] != holder:
+                    raise LeaseNotHeld(f"lease for shard '{shard}' not held by {holder}")
+                ttl_val = float(ttl if ttl is not None else row["ttl"])
+                heartbeat_val = float(heartbeat if heartbeat is not None else row["heartbeat_interval"])
+                expires_at = now + ttl_val
+                conn.execute(
+                    "UPDATE leases SET ttl = ?, heartbeat_interval = ?, updated_at = ?, expires_at = ? WHERE shard = ?",
+                    (ttl_val, heartbeat_val, now, expires_at, shard),
+                )
+                refreshed = conn.execute("SELECT * FROM leases WHERE shard = ?", (shard,)).fetchone()
+                renewed[shard] = self._row_to_lease(refreshed)
+        return renewed
+
+    def release(self, shards: Sequence[str], holder: str) -> None:
+        unique_shards = sorted({s.strip() for s in shards if s and s.strip()})
+        if not unique_shards:
+            return
+        with self._transaction() as conn:
+            now = self._now()
+            self._purge_expired(conn, now)
+            for shard in unique_shards:
+                row = conn.execute("SELECT * FROM leases WHERE shard = ?", (shard,)).fetchone()
+                if row is None:
+                    continue
+                if row["holder"] != holder:
+                    raise LeaseNotHeld(
+                        f"cannot release shard '{shard}' not held by {holder}"
+                    )
+                conn.execute("DELETE FROM leases WHERE shard = ?", (shard,))
+
+    def active(self) -> List[Lease]:
+        with self._transaction() as conn:
+            now = self._now()
+            self._purge_expired(conn, now)
+            rows = conn.execute("SELECT * FROM leases").fetchall()
+        return [self._row_to_lease(r) for r in rows]
+
+
+_DEFAULT_MANAGER = LeaseManager()
+
+
+def acquire(
+    shards: Sequence[str],
+    holder: str,
+    ttl: Optional[float] = None,
+    heartbeat: Optional[float] = None,
+    timeout: Optional[float] = None,
+    retry_interval: Optional[float] = None,
+) -> Dict[str, Lease]:
+    return _DEFAULT_MANAGER.acquire(shards, holder, ttl, heartbeat, timeout, retry_interval)
+
+
+def renew(
+    shards: Sequence[str],
+    holder: str,
+    ttl: Optional[float] = None,
+    heartbeat: Optional[float] = None,
+) -> Dict[str, Lease]:
+    return _DEFAULT_MANAGER.renew(shards, holder, ttl, heartbeat)
+
+
+def release(shards: Sequence[str], holder: str) -> None:
+    _DEFAULT_MANAGER.release(shards, holder)
+
+
+def active_leases() -> List[Lease]:
+    return _DEFAULT_MANAGER.active()
+
+
+__all__ = [
+    "Lease",
+    "LeaseError",
+    "LeaseTimeout",
+    "LeaseNotHeld",
+    "LeaseManager",
+    "acquire",
+    "renew",
+    "release",
+    "active_leases",
+]

--- a/src/multiai/orchestrator/prompt_guard.py
+++ b/src/multiai/orchestrator/prompt_guard.py
@@ -1,1 +1,44 @@
-def sanitize(text): return text
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+
+class PromptRejected(ValueError):
+    """Raised when a prompt violates guardrails."""
+
+
+_DEFAULT_MAX_LENGTH = 4096
+_BLOCKED_PATTERNS: tuple[str, ...] = (
+    r"\b(?:rm\s+-rf|drop\s+table|sudo\s+rm)\b",
+    r"\b(?:bypass|jailbreak|ignore\s+policy)\b",
+    r"\b(?:exfiltrate|leak\s+data|steal\s+secrets)\b",
+)
+
+
+def _strip_control(text: str) -> str:
+    return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", " ", text)
+
+
+def sanitize(text: str, *, max_length: int = _DEFAULT_MAX_LENGTH, blocked_patterns: Iterable[str] | None = None) -> str:
+    """Normalize and vet prompts before dispatching them to models."""
+    if text is None:
+        raise PromptRejected("prompt is required")
+
+    cleaned = _strip_control(str(text)).strip()
+    if not cleaned:
+        raise PromptRejected("prompt cannot be empty")
+
+    if len(cleaned) > max_length:
+        cleaned = cleaned[:max_length].rstrip()
+
+    patterns = tuple(blocked_patterns) if blocked_patterns else _BLOCKED_PATTERNS
+    lowered = cleaned.lower()
+    for pattern in patterns:
+        if re.search(pattern, lowered, flags=re.IGNORECASE):
+            raise PromptRejected(f"prompt rejected by guard pattern: {pattern}")
+
+    return cleaned
+
+
+__all__ = ["PromptRejected", "sanitize"]

--- a/tools/gpt_math_validate.py
+++ b/tools/gpt_math_validate.py
@@ -1,4 +1,48 @@
 from __future__ import annotations
+
+import argparse
+import pathlib
 import sys
-print("GPT-Math-Validate (stub): OK")
-sys.exit(0)
+from typing import Iterable
+
+
+class MathValidationError(RuntimeError):
+    """Raised when math validation fails."""
+
+
+_SUSPICIOUS_TOKENS = ("TODO", "nan", "div0", "??")
+
+
+def _validate_file(path: pathlib.Path) -> None:
+    if not path.exists():
+        raise MathValidationError(f"missing file: {path}")
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    lowered = text.lower()
+    for token in _SUSPICIOUS_TOKENS:
+        if token.lower() in lowered:
+            raise MathValidationError(f"math validation failed: token '{token}' in {path}")
+
+
+def _validate(paths: Iterable[str]) -> None:
+    for raw in paths:
+        if not raw:
+            continue
+        _validate_file(pathlib.Path(raw))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run GPT math validator checks")
+    parser.add_argument("paths", nargs="*", help="Paths to inspect for math integrity")
+    args = parser.parse_args()
+
+    try:
+        _validate(args.paths)
+    except MathValidationError as exc:
+        print(f"GPT-Math-Validate: {exc}", file=sys.stderr)
+        raise SystemExit(3)
+
+    print("GPT-Math-Validate: pass")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tools/llama_guard.py
+++ b/tools/llama_guard.py
@@ -1,8 +1,70 @@
+from __future__ import annotations
+
 import argparse
-def main():
-    ap=argparse.ArgumentParser()
-    ap.add_argument("--policy", required=True)
-    a=ap.parse_args()
-    open(a.policy,"r",encoding="utf-8").read(256)
-    print("llama_guard: ok")
-if __name__=="__main__": main()
+import sys
+from typing import Iterable, List
+
+
+class PolicyViolation(RuntimeError):
+    """Raised when the prompt violates the guard policy."""
+
+
+_DEFAULT_BLOCKED = (
+    "prompt injection",
+    "ignore previous",
+    "override safety",
+    "jailbreak",
+    "rm -rf",
+    "drop table",
+)
+
+
+def _load_policy(path: str) -> List[str]:
+    blocked: List[str] = []
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                if ":" in stripped:
+                    _, value = stripped.split(":", 1)
+                    stripped = value.strip()
+                blocked.append(stripped)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"policy file not found: {path}") from exc
+    return blocked or list(_DEFAULT_BLOCKED)
+
+
+def _enforce(prompt: str, blocked_terms: Iterable[str]) -> None:
+    lowered = prompt.lower()
+    for term in blocked_terms:
+        term_lower = term.lower().strip()
+        if not term_lower:
+            continue
+        if term_lower in lowered:
+            raise PolicyViolation(f"blocked term detected: {term}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Llama Guard policy checks")
+    parser.add_argument("--policy", required=True, help="Path to guard policy file")
+    args = parser.parse_args()
+
+    prompt = sys.stdin.read()
+    if not prompt.strip():
+        print("llama_guard: empty prompt supplied", file=sys.stderr)
+        raise SystemExit(2)
+
+    try:
+        blocked_terms = _load_policy(args.policy)
+        _enforce(prompt, blocked_terms)
+    except PolicyViolation as exc:
+        print(f"llama_guard: policy violation - {exc}", file=sys.stderr)
+        raise SystemExit(3)
+
+    print("llama_guard: pass")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tools/protocol_auditor.py
+++ b/tools/protocol_auditor.py
@@ -1,11 +1,83 @@
+from __future__ import annotations
+
 import argparse
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--policy", required=True)
-    ap.add_argument("--rules", required=True)
-    a = ap.parse_args()
-    open(a.policy,"r",encoding="utf-8").read(256)
-    open(a.rules,"r",encoding="utf-8").read(256)
-    print("protocol_auditor: ok")
-if __name__ == "__main__":
+import sys
+from typing import Dict, List, Tuple
+
+
+class ProtocolViolation(RuntimeError):
+    """Raised when the orchestrator task violates governance rules."""
+
+
+_KEYWORD_MAP: Dict[str, Tuple[str, ...]] = {
+    "egress.secrets": ("secret", "credential", "password"),
+    "egress.raw_data": ("raw dump", "export dataset", "full database"),
+    "gpu_required": ("cpu only",),
+}
+
+
+def _load_denied_capabilities(path: str) -> List[str]:
+    denied: List[str] = []
+    stack: List[Tuple[int, str]] = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+                continue
+            indent = len(raw_line) - len(raw_line.lstrip(" "))
+            stripped = raw_line.strip()
+            if ":" not in stripped:
+                continue
+            key, value = stripped.split(":", 1)
+            key = key.strip()
+            value = value.strip()
+            while stack and stack[-1][0] >= indent:
+                stack.pop()
+            if not value:
+                stack.append((indent, key))
+                continue
+            if "deny" in value.lower():
+                path_components = [frame[1] for frame in stack] + [key]
+                denied.append(".".join(path_components))
+    return denied
+
+
+def _enforce(prompt: str, policy_path: str, rules_path: str) -> None:
+    denied = set(_load_denied_capabilities(rules_path))
+    if not denied:
+        return
+    lowered = prompt.lower()
+    for capability in denied:
+        keywords = _KEYWORD_MAP.get(capability, ())
+        for kw in keywords:
+            if kw in lowered:
+                raise ProtocolViolation(
+                    f"capability '{capability}' is denied but keyword '{kw}' was requested"
+                )
+    # Basic policy sanity: require mention of policy identifier to ensure context.
+    policy_text = open(policy_path, "r", encoding="utf-8").read().lower()
+    if "thresholds" in policy_text and "threshold" not in lowered:
+        raise ProtocolViolation("prompt missing acknowledgement of gate thresholds")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run protocol governance audit")
+    parser.add_argument("--policy", required=True, help="Path to governance policy file")
+    parser.add_argument("--rules", required=True, help="Path to protocol rules file")
+    args = parser.parse_args()
+
+    prompt = sys.stdin.read()
+    if not prompt.strip():
+        print("protocol_auditor: empty prompt supplied", file=sys.stderr)
+        raise SystemExit(2)
+
+    try:
+        _enforce(prompt, args.policy, args.rules)
+    except ProtocolViolation as exc:
+        print(f"protocol_auditor: violation - {exc}", file=sys.stderr)
+        raise SystemExit(3)
+
+    print("protocol_auditor: pass")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()


### PR DESCRIPTION
## Summary
- replace the placeholder shard lock helper with a SQLite-backed lease manager that enforces TTLs, heartbeats, and persistent state under `state/`
- harden the orchestrator gateway to sanitize prompts, acquire shard leases, run policy/math validators, and record attestation artifacts plus governance log entries
- upgrade validator CLIs to raise on violations and record GitHub App push metadata alongside generated attestations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cee82154cc8320a330e29510bc252a