### PR TITLE
Add Litecoin whale tracker and integrate whale metrics

### DIFF
--- a/src/multiai/cli/main.py
+++ b/src/multiai/cli/main.py
@@ -47,17 +47,23 @@ def daily_merge(off_dir, on_dir, out):
 @run.command("dataops")
 @click.option("--on", "on_path", required=True)
 @click.option("--off", "off_path", required=True)
+@click.option("--whales", "whales_path", default=None)
 @click.option("--out", "out_path", required=True)
-def dataops(on_path, off_path, out_path):
+def dataops(on_path, off_path, whales_path, out_path):
     import pandas as pd
     print("[bold]Step 1/4:[/] Quantize to 1s (forward snap + dedupe)")
     q_on = quantize_to_1s(pd.read_parquet(on_path))
     q_off = quantize_to_1s(pd.read_parquet(off_path))
+    q_whales = None
+    if whales_path:
+        print("[bold]Step 1b/4:[/] Quantize whale aggregates to 1s grid")
+        q_whales = quantize_to_1s(pd.read_parquet(whales_path))
     print("[bold]Step 2/4:[/] Split list/object columns (if present)")
     s_on = split_object_columns_if_present(q_on)
     s_off = split_object_columns_if_present(q_off)
-    print("[bold]Step 3/4:[/] Merge on/off into single file with strict schema")
-    merge_on_off(s_on, s_off, out_path)
+    s_whales = split_object_columns_if_present(q_whales) if q_whales is not None else None
+    print("[bold]Step 3/4:[/] Merge on/off{} into single file with strict schema".format(" + whales" if s_whales is not None else ""))
+    merge_on_off(s_on, s_off, s_whales, out_path=out_path)
     print(f"[green]OK[/] Merged file written to: {out_path}")
 
 if __name__ == "__main__":

--- a/src/multiai/collectors/onchain/whale_tracker.py
+++ b/src/multiai/collectors/onchain/whale_tracker.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Deque, Dict, List, Optional
+
+import httpx
+
+from multiai.collectors.onchain import ltc_mempool
+from multiai.collectors.rotate import RollingParquetWriter
+
+WINDOW_SECONDS_DEFAULT = 10 * 60  # 10 minutes
+
+
+def utc_ms() -> int:
+    """Return the current UTC time in milliseconds."""
+    return int(datetime.now(timezone.utc).timestamp() * 1000)
+
+
+@dataclass
+class WhaleEvent:
+    txid: str
+    timestamp_ms: int
+    value_ltc_total: float
+    inputs_count: int
+    outputs_count: int
+    block_height: int
+    first_seen_ms: int
+
+    def to_row(self) -> Dict[str, object]:
+        return {
+            "timestamp": self.timestamp_ms,
+            "timestamp_ms": self.timestamp_ms,
+            "txid": self.txid,
+            "value_ltc_total": float(self.value_ltc_total),
+            "inputs_count": int(self.inputs_count),
+            "outputs_count": int(self.outputs_count),
+            "block_height": int(self.block_height),
+            "first_seen_ms": int(self.first_seen_ms),
+        }
+
+
+class WhaleRingBuffer:
+    def __init__(self, window_seconds: int = WINDOW_SECONDS_DEFAULT) -> None:
+        self.window_ms = window_seconds * 1000
+        self._events: Deque[WhaleEvent] = deque()
+
+    def add(self, event: WhaleEvent) -> None:
+        self._events.append(event)
+
+    def prune(self, now_ms: int) -> List[WhaleEvent]:
+        cutoff = now_ms - self.window_ms
+        removed: List[WhaleEvent] = []
+        while self._events and self._events[0].timestamp_ms < cutoff:
+            removed.append(self._events.popleft())
+        return removed
+
+    def snapshot(self) -> List[WhaleEvent]:
+        return list(self._events)
+
+
+class WhaleTracker:
+    def __init__(
+        self,
+        threshold_ltc: float,
+        top_n: int = 5,
+        *,
+        window_seconds: int = WINDOW_SECONDS_DEFAULT,
+        event_writer: Optional[RollingParquetWriter] = None,
+        metrics_writer: Optional[RollingParquetWriter] = None,
+        time_fn: Callable[[], int] = utc_ms,
+    ) -> None:
+        if threshold_ltc <= 0:
+            raise ValueError("threshold_ltc must be positive")
+        if top_n <= 0:
+            raise ValueError("top_n must be positive")
+        self.threshold_ltc = float(threshold_ltc)
+        self.top_n = int(top_n)
+        self._buffer = WhaleRingBuffer(window_seconds)
+        self._event_writer = event_writer
+        self._metrics_writer = metrics_writer
+        self._time_fn = time_fn
+        self._events_by_txid: Dict[str, WhaleEvent] = {}
+        self._first_seen: Dict[str, int] = {}
+        self._last_tick_ts: Optional[int] = None
+        self._last_metrics: Optional[Dict[str, object]] = None
+
+    @staticmethod
+    def _total_output_value(tx: Dict[str, object]) -> float:
+        total = 0.0
+        for vout in tx.get("vout", []) or []:
+            value = None
+            if isinstance(vout, dict):
+                value = vout.get("value")
+            if value is None:
+                continue
+            try:
+                total += float(value)
+            except (TypeError, ValueError):
+                continue
+        return total
+
+    def _counts(self, tx: Dict[str, object]) -> tuple[int, int]:
+        vin = tx.get("vin", []) or []
+        vout = tx.get("vout", []) or []
+        return len(vin), len(vout)
+
+    def _handle_tx(
+        self,
+        tx: Dict[str, object],
+        *,
+        seen_ms: Optional[int] = None,
+        block_height: Optional[int] = None,
+    ) -> Optional[WhaleEvent]:
+        txid = tx.get("txid") or tx.get("hash")
+        if not txid:
+            return None
+        total_value = self._total_output_value(tx)
+        if total_value < self.threshold_ltc:
+            return None
+        now_ms = int(seen_ms if seen_ms is not None else self._time_fn())
+        first_seen = self._first_seen.setdefault(txid, now_ms)
+        event = self._events_by_txid.get(txid)
+        if event is None:
+            inputs_count, outputs_count = self._counts(tx)
+            event = WhaleEvent(
+                txid=txid,
+                timestamp_ms=first_seen,
+                value_ltc_total=total_value,
+                inputs_count=inputs_count,
+                outputs_count=outputs_count,
+                block_height=int(block_height) if block_height is not None else -1,
+                first_seen_ms=first_seen,
+            )
+            self._events_by_txid[txid] = event
+            self._buffer.add(event)
+            if self._event_writer is not None:
+                self._event_writer.write_row(event.to_row())
+        else:
+            # Update totals if they changed and enrich block height when known.
+            event.value_ltc_total = max(event.value_ltc_total, total_value)
+            if block_height is not None and block_height >= 0:
+                new_height = int(block_height)
+                height_changed = event.block_height != new_height
+                event.block_height = new_height
+                if height_changed and self._event_writer is not None:
+                    # Emit an updated row reflecting confirmation metadata.
+                    self._event_writer.write_row(event.to_row())
+        return event
+
+    def process_mempool_tx(self, tx: Dict[str, object], *, seen_ms: Optional[int] = None) -> Optional[WhaleEvent]:
+        return self._handle_tx(tx, seen_ms=seen_ms, block_height=-1)
+
+    def process_block(self, block: Dict[str, object], *, seen_ms: Optional[int] = None) -> List[WhaleEvent]:
+        now_ms = int(seen_ms if seen_ms is not None else self._time_fn())
+        block_height = block.get("height")
+        results: List[WhaleEvent] = []
+        for tx in block.get("tx", []) or []:
+            if isinstance(tx, dict):
+                evt = self._handle_tx(tx, seen_ms=now_ms, block_height=block_height)
+                if evt is not None:
+                    results.append(evt)
+        return results
+
+    def _grid_second(self, ts_ms: int) -> int:
+        return (ts_ms // 1000) * 1000
+
+    def tick(self, now_ms: Optional[int] = None) -> Dict[str, object]:
+        ts = int(now_ms if now_ms is not None else self._time_fn())
+        grid_ts = self._grid_second(ts)
+        if self._last_tick_ts == grid_ts and self._last_metrics is not None:
+            return dict(self._last_metrics)
+        removed = self._buffer.prune(grid_ts)
+        for ev in removed:
+            self._events_by_txid.pop(ev.txid, None)
+            self._first_seen.pop(ev.txid, None)
+        events = self._buffer.snapshot()
+        count = len(events)
+        total_value = sum(e.value_ltc_total for e in events)
+        avg_value = total_value / count if count else 0.0
+        max_value = max((e.value_ltc_total for e in events), default=0.0)
+        top_values = sorted((e.value_ltc_total for e in events), reverse=True)
+        top_sum = sum(top_values[: self.top_n]) if top_values else 0.0
+        metrics = {
+            "timestamp": grid_ts,
+            "whale_tx_count_10m": int(count),
+            "whale_total_value_ltc_10m": float(total_value),
+            "whale_avg_value_ltc_10m": float(avg_value),
+            "whale_max_value_ltc_10m": float(max_value),
+            "whale_topN_sum_ltc_10m": float(top_sum),
+            "threshold_ltc_effective": float(self.threshold_ltc),
+        }
+        if self._metrics_writer is not None:
+            self._metrics_writer.write_row(metrics)
+        self._last_tick_ts = grid_ts
+        self._last_metrics = metrics
+        return dict(metrics)
+
+    def close(self) -> None:
+        if self._event_writer is not None:
+            self._event_writer.close()
+        if self._metrics_writer is not None:
+            self._metrics_writer.close()
+
+
+def run_ltc_whale_tracker(
+    rpc_url: str,
+    rpc_user: str,
+    rpc_pass: str,
+    out_dir: str,
+    *,
+    threshold_ltc: float = 10.0,
+    top_n: int = 5,
+    rotate_minutes: int = 90,
+    poll_interval_ms: int = 200,
+) -> None:
+    """Long-running whale tracker loop for Litecoin."""
+    event_writer = RollingParquetWriter(out_dir, prefix="whale_events", rotate_minutes=rotate_minutes)
+    metrics_writer = RollingParquetWriter(out_dir, prefix="whale_metrics", rotate_minutes=rotate_minutes)
+    tracker = WhaleTracker(
+        threshold_ltc=threshold_ltc,
+        top_n=top_n,
+        event_writer=event_writer,
+        metrics_writer=metrics_writer,
+    )
+    auth = (rpc_user, rpc_pass)
+    last_mempool_poll = 0
+    last_second = None
+    best_hash: Optional[str] = None
+    try:
+        with httpx.Client(base_url=rpc_url, auth=auth) as client:
+            while True:
+                now = utc_ms()
+                if now - last_mempool_poll >= poll_interval_ms:
+                    try:
+                        mempool = ltc_mempool.rpc_call(client, "getrawmempool", [True]) or {}
+                    except Exception:
+                        mempool = {}
+                    if isinstance(mempool, dict):
+                        for txid, tx in mempool.items():
+                            if isinstance(tx, dict):
+                                tx.setdefault("txid", txid)
+                                tracker.process_mempool_tx(tx, seen_ms=now)
+                    last_mempool_poll = now
+                try:
+                    current_hash = ltc_mempool.rpc_call(client, "getbestblockhash")
+                except Exception:
+                    current_hash = None
+                if current_hash and current_hash != best_hash:
+                    try:
+                        block = ltc_mempool.rpc_call(client, "getblock", [current_hash, 2]) or {}
+                    except Exception:
+                        block = {}
+                    tracker.process_block(block, seen_ms=now)
+                    best_hash = current_hash
+                sec = now // 1000
+                if last_second is None or sec > last_second:
+                    tracker.tick(sec * 1000)
+                    last_second = sec
+                time.sleep(max(poll_interval_ms / 1000.0 / 4.0, 0.05))
+    finally:
+        tracker.close()
+
+
+def main() -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Litecoin whale tracker")
+    ap.add_argument("--rpc-url", default="http://127.0.0.1:9332")
+    ap.add_argument("--rpc-user", required=True)
+    ap.add_argument("--rpc-pass", required=True)
+    ap.add_argument("--outdir", required=True)
+    ap.add_argument("--threshold-ltc", type=float, default=10.0)
+    ap.add_argument("--top-n", type=int, default=5)
+    ap.add_argument("--rotate-minutes", type=int, default=90)
+    args = ap.parse_args()
+    run_ltc_whale_tracker(
+        args.rpc_url,
+        args.rpc_user,
+        args.rpc_pass,
+        args.outdir,
+        threshold_ltc=args.threshold_ltc,
+        top_n=args.top_n,
+        rotate_minutes=args.rotate_minutes,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/multiai/dataops/merge_on_off.py
+++ b/src/multiai/dataops/merge_on_off.py
@@ -1,41 +1,79 @@
 import os
 from typing import Union
 import pandas as pd
-from pathlib import Path
+
 
 def _ensure_df(obj: Union[str, pd.DataFrame]) -> pd.DataFrame:
     if isinstance(obj, str):
         return pd.read_parquet(obj)
     return obj.copy()
 
+
 def _looks_like_path(val: Union[str, os.PathLike]) -> bool:
     s = str(val)
     return s.endswith(".parquet") or ("/" in s) or ("\\" in s)
 
-def merge_on_off(quant_off: Union[str, pd.DataFrame],
-                 quant_on: Union[str, pd.DataFrame],
-                 ts_col: str = "timestamp",
-                 out_path: Union[str, os.PathLike, None] = None) -> pd.DataFrame:
+def merge_on_off(
+    quant_off: Union[str, pd.DataFrame],
+    quant_on: Union[str, pd.DataFrame],
+    quant_whales: Union[str, pd.DataFrame, None] = None,
+    ts_col: str = "timestamp",
+    out_path: Union[str, os.PathLike, None] = None,
+) -> pd.DataFrame:
+    """Strict inner-join of off-chain/on-chain/whale frames on identical 1s timestamps.
+
+    Parameters
+    ----------
+    quant_off, quant_on
+        Either DataFrames or paths to parquet files already quantized to the
+        1-second grid.
+    quant_whales
+        Optional third frame containing whale aggregates to merge on the same
+        timestamp key. May be ``None``.
+    ts_col
+        Timestamp column name. Defaults to ``"timestamp"``.
+    out_path
+        Optional path to persist the merged result.
+
+    Notes
+    -----
+    Backward compatible with the previous call signature where the 3rd
+    positional argument was ``out_path``.
     """
-    Strict inner-join on identical 1-second timestamps. Errors if NaNs remain.
-    - Accepts DataFrames or parquet paths.
-    - Backward-compatible: if ts_col looks like a path and out_path is None,
-      treat ts_col as out_path and use ts_col="timestamp".
-    """
+    # Back-compat: third positional argument may still be the output path.
+    if out_path is None and ts_col == "timestamp" and quant_whales is not None and _looks_like_path(quant_whales):
+        out_path = str(quant_whales)
+        quant_whales = None
+
     # Back-compat with tests that pass a path as the 3rd positional arg
     if out_path is None and _looks_like_path(ts_col):
         out_path = str(ts_col)
         ts_col = "timestamp"
 
     off_df = _ensure_df(quant_off)
-    on_df  = _ensure_df(quant_on)
+    on_df = _ensure_df(quant_on)
+    whale_df = _ensure_df(quant_whales) if quant_whales is not None else None
 
     if ts_col not in off_df.columns:
         raise ValueError(f"off-chain frame missing '{ts_col}'")
     if ts_col not in on_df.columns:
         raise ValueError(f"on-chain frame missing '{ts_col}'")
+    if whale_df is not None and ts_col not in whale_df.columns:
+        raise ValueError(f"whale frame missing '{ts_col}'")
 
     merged = pd.merge(off_df, on_df, on=ts_col, how="inner", suffixes=("_off", "_on"))
+
+    if whale_df is not None:
+        whale_df = whale_df.drop_duplicates(subset=[ts_col], keep="last")
+        whale_df = whale_df.sort_values(ts_col)
+        merged = pd.merge(merged, whale_df, on=ts_col, how="left")
+        whale_cols = [c for c in whale_df.columns if c != ts_col]
+        for col in whale_cols:
+            if col.startswith("whale_"):
+                merged[col] = merged[col].fillna(0.0)
+        if "threshold_ltc_effective" in whale_cols:
+            merged["threshold_ltc_effective"] = merged["threshold_ltc_effective"].ffill()
+            merged["threshold_ltc_effective"] = merged["threshold_ltc_effective"].fillna(0.0)
 
     if merged.isna().any().any():
         bad = merged.columns[merged.isna().any()].tolist()

--- a/state/pipeline.json
+++ b/state/pipeline.json
@@ -3,5 +3,24 @@
   "with_targets": "outputs/merged_with_targets.parquet",
   "with_features": "outputs/merged_with_features.parquet",
   "train_path": "outputs/train.parquet",
-  "test_path": "outputs/test.parquet"
+  "test_path": "outputs/test.parquet",
+  "whale_metrics_schema": [
+    "timestamp",
+    "whale_tx_count_10m",
+    "whale_total_value_ltc_10m",
+    "whale_avg_value_ltc_10m",
+    "whale_max_value_ltc_10m",
+    "whale_topN_sum_ltc_10m",
+    "threshold_ltc_effective"
+  ],
+  "whale_events_schema": [
+    "timestamp",
+    "timestamp_ms",
+    "txid",
+    "value_ltc_total",
+    "inputs_count",
+    "outputs_count",
+    "block_height",
+    "first_seen_ms"
+  ]
 }

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -13,5 +13,33 @@ def test_merge_no_nans(tmp_path):
     outp = tmp_path / 'm.parquet'
     merge_on_off(on, off, outp)
     m = pd.read_parquet(outp)
-    assert m.isna().any().any() == False
+    assert not m.isna().any().any()
     assert list(m.columns)[0] == 'timestamp'
+
+
+def test_merge_with_whales():
+    ts = pd.to_datetime(['2025-01-01T00:00:01Z', '2025-01-01T00:00:02Z'], utc=True)
+    off = pd.DataFrame({
+        'timestamp': ts,
+        'b_off': [20, 21],
+    })
+    on = pd.DataFrame({
+        'timestamp': ts,
+        'a_on': [10, 11],
+    })
+    whales = pd.DataFrame({
+        'timestamp': ts,
+        'whale_tx_count_10m': [0, 2],
+        'whale_total_value_ltc_10m': [0.0, 140.0],
+        'whale_avg_value_ltc_10m': [0.0, 70.0],
+        'whale_max_value_ltc_10m': [0.0, 80.0],
+        'whale_topN_sum_ltc_10m': [0.0, 140.0],
+        'threshold_ltc_effective': [50.0, 50.0],
+    })
+
+    merged = merge_on_off(off, on, whales)
+
+    for col in ['whale_tx_count_10m', 'whale_total_value_ltc_10m', 'whale_avg_value_ltc_10m']:
+        assert col in merged.columns
+    assert merged['whale_tx_count_10m'].tolist() == [0, 2]
+    assert not merged.isna().any().any()

--- a/tests/test_whale_tracker.py
+++ b/tests/test_whale_tracker.py
@@ -1,0 +1,111 @@
+import pandas as pd
+import pytest
+
+from multiai.collectors.onchain.whale_tracker import WhaleTracker
+from multiai.collectors.rotate import RollingParquetWriter
+
+
+class FakeClock:
+    def __init__(self, start_ms: int) -> None:
+        self._now = start_ms
+
+    def set(self, ts_ms: int) -> None:
+        self._now = ts_ms
+
+    def __call__(self) -> int:
+        return self._now
+
+
+def _mk_tx(txid: str, value: float, *, inputs: int = 1, outputs: int = 1) -> dict:
+    per_output = value / outputs
+    return {
+        "txid": txid,
+        "vin": [{}] * inputs,
+        "vout": [{"value": per_output} for _ in range(outputs)],
+    }
+
+
+def test_whale_tracker_detection_metrics_and_parquet(tmp_path):
+    base_ms = 1_700_000_000_000
+    clock = FakeClock(base_ms)
+    writer_dir = tmp_path / "whales"
+    event_writer = RollingParquetWriter(writer_dir, prefix="whale_events", rotate_minutes=1)
+    metrics_writer = RollingParquetWriter(writer_dir, prefix="whale_metrics", rotate_minutes=1)
+    tracker = WhaleTracker(
+        threshold_ltc=50.0,
+        top_n=2,
+        event_writer=event_writer,
+        metrics_writer=metrics_writer,
+        time_fn=clock,
+    )
+
+    tracker.process_mempool_tx(_mk_tx("tx1", 60.0, inputs=2, outputs=2), seen_ms=base_ms)
+    metrics = tracker.tick(base_ms)
+    assert metrics["timestamp"] % 1000 == 0
+    assert metrics["whale_tx_count_10m"] == 1
+    assert metrics["whale_total_value_ltc_10m"] == pytest.approx(60.0)
+    assert metrics["whale_avg_value_ltc_10m"] == pytest.approx(60.0)
+    assert metrics["whale_max_value_ltc_10m"] == pytest.approx(60.0)
+    assert metrics["whale_topN_sum_ltc_10m"] == pytest.approx(60.0)
+    assert metrics["threshold_ltc_effective"] == pytest.approx(50.0)
+
+    # Values below threshold are ignored.
+    tracker.process_mempool_tx(_mk_tx("tiny", 5.0), seen_ms=base_ms + 500)
+    metrics = tracker.tick(base_ms + 500)
+    assert metrics["whale_tx_count_10m"] == 1
+
+    # Add a second whale 30 seconds later.
+    clock.set(base_ms + 30_000)
+    tracker.process_mempool_tx(_mk_tx("tx2", 80.0, inputs=3, outputs=4), seen_ms=clock())
+    metrics = tracker.tick(clock())
+    assert metrics["whale_tx_count_10m"] == 2
+    assert metrics["whale_total_value_ltc_10m"] == pytest.approx(140.0)
+    assert metrics["whale_avg_value_ltc_10m"] == pytest.approx(70.0)
+    assert metrics["whale_max_value_ltc_10m"] == pytest.approx(80.0)
+    assert metrics["whale_topN_sum_ltc_10m"] == pytest.approx(140.0)
+
+    # Confirmation should not double-count but should update block height metadata.
+    block = {"height": 2_500_000, "tx": [_mk_tx("tx1", 60.0)]}
+    clock.set(base_ms + 40_000)
+    tracker.process_block(block, seen_ms=clock())
+    metrics = tracker.tick(clock())
+    assert metrics["whale_tx_count_10m"] == 2
+
+    # After 10 minutes the first whale falls out of the window.
+    clock.set(base_ms + 601_000)
+    metrics = tracker.tick(clock())
+    assert metrics["whale_tx_count_10m"] == 1
+    assert metrics["whale_total_value_ltc_10m"] == pytest.approx(80.0)
+
+    # And eventually the buffer empties entirely.
+    clock.set(base_ms + 661_000)
+    metrics = tracker.tick(clock())
+    assert metrics["whale_tx_count_10m"] == 0
+    assert metrics["whale_total_value_ltc_10m"] == 0.0
+    assert metrics["whale_max_value_ltc_10m"] == 0.0
+
+    tracker.close()
+
+    event_files = sorted(writer_dir.glob("whale_events_*.parquet"))
+    assert event_files, "whale event parquet should be written"
+    events_df = pd.read_parquet(event_files[0])
+    assert {"txid", "timestamp_ms", "value_ltc_total", "inputs_count", "outputs_count", "block_height", "first_seen_ms"} <= set(events_df.columns)
+    assert set(events_df["txid"]) == {"tx1", "tx2"}
+    tx1_rows = events_df[events_df["txid"] == "tx1"]
+    assert (tx1_rows["block_height"] == -1).any()
+    assert tx1_rows["block_height"].iloc[-1] == 2_500_000
+
+    metrics_files = sorted(writer_dir.glob("whale_metrics_*.parquet"))
+    assert metrics_files, "per-second whale metrics parquet should be written"
+    metrics_df = pd.read_parquet(metrics_files[0])
+    expected_cols = {
+        "timestamp",
+        "whale_tx_count_10m",
+        "whale_total_value_ltc_10m",
+        "whale_avg_value_ltc_10m",
+        "whale_max_value_ltc_10m",
+        "whale_topN_sum_ltc_10m",
+        "threshold_ltc_effective",
+    }
+    assert expected_cols <= set(metrics_df.columns)
+    assert (metrics_df["timestamp"] % 1000 == 0).all()


### PR DESCRIPTION
## Summary
- add a Litecoin whale tracker that classifies high-value activity, maintains a 10-minute buffer, and writes raw events plus per-second aggregates
- expose whale aggregates through the data-ops CLI and merge pipeline so the 1-second parquet now carries whale metrics alongside on/off-chain features
- cover the tracker and merge workflow with regression tests and record the whale schemas in state metadata

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68ceea99bde483209793555b996c0263