### PR TITLE
Fix orchestrator merge wiring and add integration coverage

### DIFF
--- a/src/multiai/dataops/merge_on_off.py
+++ b/src/multiai/dataops/merge_on_off.py
@@ -86,3 +86,8 @@ def merge_on_off(
         merged.to_parquet(str(out_path), index=False)
 
     return merged
+
+
+def run(**kwargs) -> pd.DataFrame:
+    """Convenience entrypoint mirroring the orchestrator's expectations."""
+    return merge_on_off(**kwargs)

--- a/tests/test_orchestrator_pipeline.py
+++ b/tests/test_orchestrator_pipeline.py
@@ -27,17 +27,44 @@ def test_orchestrator_pipeline_end_to_end(tmp_path, monkeypatch):
     periods = 400
     timestamps = pd.date_range("2025-01-01", periods=periods, freq="s", tz="UTC")
     price = 100 + np.cumsum(rng.normal(0, 0.05, size=periods))
-    merged_df = pd.DataFrame({
+    off_df = pd.DataFrame({
         "timestamp": timestamps,
         "trade_price": price,
         "best_bid": price - 0.01,
         "best_ask": price + 0.01,
         "volume": rng.lognormal(mean=0.0, sigma=0.1, size=periods),
     })
+    off_q1s_path = tmp_path / "off_chain_q1s.parquet"
+    off_split_path = tmp_path / "off_chain_q1s_split.parquet"
+    off_df.to_parquet(off_q1s_path, index=False)
+    off_df.to_parquet(off_split_path, index=False)
+    st.set_artifact("off_chain_q1s", str(off_q1s_path))
+    st.set_artifact("off_chain_q1s_split", str(off_split_path))
 
-    merged_path = tmp_path / "merged.parquet"
-    merged_df.to_parquet(merged_path, index=False)
-    st.set_artifact("merged", str(merged_path))
+    on_df = pd.DataFrame({
+        "timestamp": timestamps,
+        "onchain_tx_count": rng.poisson(5, size=periods),
+        "onchain_avg_fee": rng.normal(0.05, 0.005, size=periods),
+    })
+    on_q1s_path = tmp_path / "on_chain_q1s.parquet"
+    on_df.to_parquet(on_q1s_path, index=False)
+    st.set_artifact("on_chain_q1s", str(on_q1s_path))
+
+    whale_counts = rng.integers(0, 3, size=periods)
+    whale_totals = rng.uniform(0.0, 200.0, size=periods)
+    whale_avg = np.where(whale_counts > 0, whale_totals / whale_counts, 0.0)
+    whales_df = pd.DataFrame({
+        "timestamp": timestamps,
+        "whale_tx_count_10m": whale_counts,
+        "whale_total_value_ltc_10m": whale_totals,
+        "whale_avg_value_ltc_10m": whale_avg,
+        "whale_max_value_ltc_10m": np.maximum(whale_totals * 0.6, whale_avg),
+        "whale_topN_sum_ltc_10m": whale_totals * 0.8,
+    })
+    whales_path = tmp_path / "whale_metrics_q1s.parquet"
+    whales_df.to_parquet(whales_path, index=False)
+    st.set_artifact("whale_metrics_q1s", str(whales_path))
+    st.set_artifact("whale_metrics_q1s_split", str(whales_path))
 
     for task_type, payload in cli.next_steps():
         q.enqueue(task_type, payload, queue_path=str(queue_path))
@@ -51,7 +78,15 @@ def test_orchestrator_pipeline_end_to_end(tmp_path, monkeypatch):
         processed.append(task["type"])
 
     final_state = st.load()
+    assert "data.merge_on_offchain" in processed
+    assert "merged" in final_state
+    merged_path = final_state["merged"]
+    assert os.path.exists(merged_path)
+    merged_df = pd.read_parquet(merged_path)
+    assert "whale_tx_count_10m" in merged_df.columns
+
     expected_keys = [
+        "merged",
         "with_targets",
         "with_features",
         "train_path",


### PR DESCRIPTION
## Summary
- update the orchestrator merge handler to invoke the concrete merge_on_off entrypoint and support optional whale metrics payloads
- add a convenience run() shim to the merge implementation and pass whale metric artifacts from next_steps when available
- expand the orchestrator integration test to exercise the merge step and verify the merged parquet is produced

## Testing
- pytest tests/test_orchestrator_pipeline.py::test_orchestrator_pipeline_end_to_end *(skipped: requires PyTorch for Bayesian LSTM pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7cfe0e6083209ccdc67d8a7ad310